### PR TITLE
Create .env.example for storing relevant env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+RESEND_API_KEY=


### PR DESCRIPTION
We (appropriately) don't check in `.env` files, but we still need a way to keep track of what ENV vars we set for local testing.

This PR adds a `.env.example` file should mirror the `.env` file, just without the actual API keys.

Anytime we make use of a new API key or env var we should update this file as well.

