### PR TITLE
Add basic report export feature to admin dashboard

### DIFF
--- a/assets/export-lib.js
+++ b/assets/export-lib.js
@@ -1,0 +1,23 @@
+
+
+async function captureBodyAsImage() {
+    const canvas = await html2canvas(document.body);
+    return canvas.toDataURL('image/png');
+}
+
+
+function downloadImage(dataUrl) {
+  // Create a temporary link element
+  const link = document.createElement('a');
+  link.href = dataUrl;
+  link.download = 'report.pdf';
+
+  // Append to DOM, trigger click, then remove
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}
+
+function downloadPDF() {
+    captureBodyAsImage().then(dataUrl => downloadImage(dataUrl));
+}

--- a/assets/export-lib.js
+++ b/assets/export-lib.js
@@ -10,7 +10,7 @@ function downloadImage(dataUrl) {
   // Create a temporary link element
   const link = document.createElement('a');
   link.href = dataUrl;
-  link.download = 'report.pdf';
+  link.download = 'report.png';
 
   // Append to DOM, trigger click, then remove
   document.body.appendChild(link);

--- a/buildcheck/views/admin_dashboard.py
+++ b/buildcheck/views/admin_dashboard.py
@@ -8,8 +8,7 @@ from buildcheck.components.navbar import navbar
 from buildcheck.components.stat_card import stat_card
 from buildcheck.components.status_tag import freq_tag
 
-
-
+HTML2CANVAS_PRO_SRC="https://unpkg.com/html2canvas-pro@1.5.11/dist/html2canvas-pro.js"
 months = list(map(lambda x: x[:3], calendar.month_name[1:]))
 
 class AdminDashState(rx.State):
@@ -20,7 +19,13 @@ class AdminDashState(rx.State):
     successes: list[dict] = []
 
 
-    def randomize_successes(self):
+    @rx.event
+    def no_op(self):
+        # needed to suppress _call_script no callback error
+        pass
+
+    async def randomize_successes(self):
+        # yield rx.call_script("alert('hi')")
         if self.successes:
             return
 
@@ -245,17 +250,24 @@ def main_content2() -> rx.Component:
     )
 
 
-
 @rx.page(route='/admin-dashboard', on_load=AdminDashState.randomize_successes)
 def am_dashboard() -> rx.Component:
     return rx.vstack(
+        rx.script(src=HTML2CANVAS_PRO_SRC),
+        rx.script(src='/export-lib.js'),
         navbar(),
-        rx.heading("Admin Dashboard", size="9"),
+        rx.flex(
+            rx.heading("Admin Dashboard", size="9"),
+            rx.button("Export Report", on_click=rx.call_script("downloadPDF()", callback=AdminDashState.no_op)),
+            justify="between",
+            align="baseline",
+            width="100%",
+        ),
         cards(),
         main_content1(),
         main_content2(),
         footer(),
-        align="center",
+        align="start",
         spacing="3",
         padding="3",
         padding_x=["1.5em", "1.5em", "3em"],


### PR DESCRIPTION
Dead simple report generation. Just exports the current page as an image.


### Description
<!-- Write a short description of the pull request for someone who hasn't looked at your code yet. -->

There are a few problems:
- text is not super clear
- includes header and footer

To make the text clearer we'd have to use some kind of headless browser approach or generate the report separately and manually, both of which are time consuming to do.

### What to Test

<!-- Describe what you want the reviewer to do to ensure the PR works -->


1. Go to `localhost:3000/admin-dashboard`
2. Click on `Export report`
3. Inspect and insure that the report was saved as an image
